### PR TITLE
ssss: build dockerized ssss using nix in docker

### DIFF
--- a/ssss/.dockerignore
+++ b/ssss/.dockerignore
@@ -6,3 +6,5 @@
 !rust-toolchain.toml
 !s4/src
 !s4/Cargo.toml
+!nix/
+!flake.*

--- a/ssss/Dockerfile
+++ b/ssss/Dockerfile
@@ -1,24 +1,15 @@
-FROM rust:1.76.0-alpine@sha256:e594a9705c4514c0e0b5ed2409f7ec34f20af09a33d242524281247b74196c43 AS builder
+FROM alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b AS builder
+
+RUN apk add nix --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 
 WORKDIR /code
 
-COPY ./rust-toolchain.toml ./
-RUN rustup show
-
-RUN mkdir -p s4/src src/ && touch s4/src/lib.rs src/lib.rs
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./s4/Cargo.toml ./s4
-RUN cargo metadata
-
-RUN apk add --no-cache musl-dev==1.2.4_git20230717-r4
-
 COPY ./ ./
-RUN cargo build --locked --release -p ssss
+RUN nix --extra-experimental-features nix-command --extra-experimental-features flakes build .
 
 FROM gcr.io/distroless/static-debian12@sha256:6dcc833df2a475be1a3d7fc951de90ac91a2cb0be237c7578b88722e48f2e56f AS ssss
 
-COPY --from=builder /code/target/release/ssss /usr/local/bin/ssss
+COPY --from=builder /code/result/ssss /usr/local/bin/ssss
 
 EXPOSE 1075
 


### PR DESCRIPTION
Pros: Nix helps with reproducibility ~~and Docker avoids cross compilation trickiness~~
Cons: community-maintained nix package, possibly worse performance because of no LTO, slower
Neutral: could share cache with build action with probably great difficulty

A build on alpine still yields a gnu/linux binary :(